### PR TITLE
Fix service installation script

### DIFF
--- a/claude-code-ui.service
+++ b/claude-code-ui.service
@@ -8,17 +8,17 @@ Wants=network-online.target
 Type=forking
 User=distiller
 Group=distiller
-WorkingDirectory=/home/distiller/claudeCodeUi
-ExecStart=/home/distiller/.nvm/versions/node/v22.17.0/bin/npm run pm2:start
-ExecReload=/home/distiller/.nvm/versions/node/v22.17.0/bin/npm run pm2:restart
-ExecStop=/home/distiller/.nvm/versions/node/v22.17.0/bin/npm run pm2:stop
+WorkingDirectory=/home/distiller/vibe-code-distiller-ui
+ExecStart=/home/distiller/.nvm/versions/node/v22.17.1/bin/npm run pm2:start
+ExecReload=/home/distiller/.nvm/versions/node/v22.17.1/bin/npm run pm2:restart
+ExecStop=/home/distiller/.nvm/versions/node/v22.17.1/bin/npm run pm2:stop
 Restart=on-failure
 RestartSec=10
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=claude-code-ui
 Environment="NODE_ENV=production"
-Environment="PATH=/home/distiller/.nvm/versions/node/v22.17.0/bin:/usr/bin:/usr/local/bin"
+Environment="PATH=/home/distiller/.nvm/versions/node/v22.17.1/bin:/usr/bin:/usr/local/bin"
 Environment="PM2_HOME=/home/distiller/.pm2"
 
 [Install]

--- a/install-service.sh
+++ b/install-service.sh
@@ -16,29 +16,62 @@ if [ "$EUID" -ne 0 ]; then
     exit 1
 fi
 
-# Update service file with correct paths and user
+# Get current user and paths
 CURRENT_USER="${SUDO_USER:-$USER}"
-sed -i "s|User=pi|User=${CURRENT_USER}|g" "${PROJECT_DIR}/${SERVICE_FILE}"
-sed -i "s|Group=pi|Group=${CURRENT_USER}|g" "${PROJECT_DIR}/${SERVICE_FILE}"
-sed -i "s|WorkingDirectory=/home/distiller/claudeCodeUi|WorkingDirectory=${PROJECT_DIR}|g" "${PROJECT_DIR}/${SERVICE_FILE}"
+echo "Installing for user: ${CURRENT_USER}"
 
-# Find npm and node paths
-NPM_PATH=$(sudo -u ${CURRENT_USER} which npm)
-NODE_PATH=$(sudo -u ${CURRENT_USER} which node)
-NPM_DIR=$(dirname "${NPM_PATH}")
+# Find npm path - source the user's bashrc to get NVM paths
+NPM_PATH=$(sudo -u ${CURRENT_USER} bash -i -c 'which npm' 2>/dev/null || echo "")
+NODE_PATH=$(sudo -u ${CURRENT_USER} bash -i -c 'which node' 2>/dev/null || echo "")
 
 if [ -z "${NPM_PATH}" ]; then
     echo "Error: npm not found. Please install Node.js first."
     exit 1
 fi
 
-# Update paths in service file
-sed -i "s|/home/distiller/.nvm/versions/node/v22.17.0/bin/npm|${NPM_PATH}|g" "${PROJECT_DIR}/${SERVICE_FILE}"
-sed -i "s|/home/distiller/.nvm/versions/node/v22.17.0/bin:|${NPM_DIR}:|g" "${PROJECT_DIR}/${SERVICE_FILE}"
-sed -i "s|Environment=\"PM2_HOME=/home/distiller/.pm2\"|Environment=\"PM2_HOME=/home/${CURRENT_USER}/.pm2\"|g" "${PROJECT_DIR}/${SERVICE_FILE}"
+NPM_DIR=$(dirname "${NPM_PATH}")
+echo "Found npm at: ${NPM_PATH}"
+echo "Found node at: ${NODE_PATH}"
+
+# Check for PM2
+PM2_PATH=$(sudo -u ${CURRENT_USER} bash -i -c 'which pm2' 2>/dev/null || echo "")
+if [ -z "${PM2_PATH}" ]; then
+    echo "PM2 not found. Installing PM2 globally..."
+    sudo -u ${CURRENT_USER} bash -i -c "${NPM_PATH} install -g pm2"
+fi
+
+# Create a fresh service file instead of modifying
+cat > "/tmp/${SERVICE_FILE}" << EOF
+[Unit]
+Description=Claude Code Web Manager
+Documentation=https://github.com/yourusername/claude-code-ui
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=forking
+User=${CURRENT_USER}
+Group=${CURRENT_USER}
+WorkingDirectory=${PROJECT_DIR}
+ExecStart=${NPM_PATH} run pm2:start
+ExecReload=${NPM_PATH} run pm2:restart
+ExecStop=${NPM_PATH} run pm2:stop
+Restart=on-failure
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=claude-code-ui
+Environment="NODE_ENV=production"
+Environment="PATH=${NPM_DIR}:/usr/bin:/usr/local/bin"
+Environment="PM2_HOME=/home/${CURRENT_USER}/.pm2"
+
+[Install]
+WantedBy=multi-user.target
+EOF
 
 # Copy service file to systemd directory
-cp "${PROJECT_DIR}/${SERVICE_FILE}" "/etc/systemd/system/${SERVICE_FILE}"
+cp "/tmp/${SERVICE_FILE}" "/etc/systemd/system/${SERVICE_FILE}"
+rm "/tmp/${SERVICE_FILE}"
 
 # Reload systemd daemon
 systemctl daemon-reload
@@ -46,7 +79,7 @@ systemctl daemon-reload
 # Enable service to start on boot
 systemctl enable ${SERVICE_NAME}
 
-# Enable network-online.target to ensure network is up
+# Enable network-online.target
 systemctl enable systemd-networkd-wait-online.service
 
 echo "Service installed successfully!"
@@ -57,5 +90,3 @@ echo "  sudo systemctl stop ${SERVICE_NAME}     # Stop the service"
 echo "  sudo systemctl restart ${SERVICE_NAME}  # Restart the service"
 echo "  sudo systemctl status ${SERVICE_NAME}   # Check service status"
 echo "  sudo journalctl -u ${SERVICE_NAME} -f  # View service logs"
-echo ""
-echo "The service will automatically start on boot after network is connected."


### PR DESCRIPTION
## Summary
- Fixed npm/node path detection using interactive bash to properly load NVM environment
- Added automatic PM2 installation if not present
- Replaced error-prone sed modifications with dynamic service file generation
- Updated service file to use correct Node.js version (v22.17.1)

## Problem
The original install script was failing because:
1. It tried to replace patterns that didn't exist in the service file (looking for 'pi' user instead of 'distiller')
2. Node version mismatch (v22.17.0 vs v22.17.1)
3. sed commands would fail silently, leaving incorrect paths

## Solution
Created a new install script that:
- Uses `bash -i -c` to properly load user's NVM environment
- Dynamically generates the service file with detected paths
- Automatically installs PM2 if missing
- Provides better error handling and user feedback