### PR TITLE
fix: remove system reboot trigger from install script

### DIFF
--- a/install-service.sh
+++ b/install-service.sh
@@ -192,9 +192,6 @@ echo "🚀 Starting service..."
 systemctl daemon-reload
 systemctl enable ${SERVICE_NAME}
 
-# Enable network-online.target for proper networking
-systemctl enable systemd-networkd-wait-online.service 2>/dev/null || true
-
 # Start the service
 systemctl start ${SERVICE_NAME}
 


### PR DESCRIPTION
Removes systemctl enable systemd-networkd-wait-online.service that was causing unwanted system reboots during PM2 installation. Service retains network dependencies via existing After=network-online.target.